### PR TITLE
Serve static files with `send`.

### DIFF
--- a/example/serve.js
+++ b/example/serve.js
@@ -1,0 +1,24 @@
+/* eslint no-console: 0 */
+import compose from 'lodash/flowRight';
+import http from 'http';
+import serve from '../src/middleware/serve';
+import status from '../src/middleware/status';
+import send from '../src/middleware/send';
+import verbs from '../src/middleware/match/verbs';
+import connect from '../src/adapter/http';
+
+const createApp = compose(
+  verbs.get('/foo', serve({ root: __dirname })),
+  compose(status(404), send()),
+);
+
+const app = createApp({
+  request() {
+    console.log('GOT REQUEST');
+  },
+  error(err) {
+    console.log('GOT ERROR', err);
+  },
+});
+
+connect(app, http.createServer()).listen(8081);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "parseurl": "^1.3.1",
     "path-to-regexp": "^1.2.1",
     "qs": "^6.0.2",
+    "send": "^0.13.1",
     "useragent": "^2.1.8",
     "webpack-assets": "^0.2.0",
     "yamlparser": "0.0.2"
@@ -35,6 +36,7 @@
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.26",
     "babel-preset-metalab": "^0.1.4",
+    "bl": "^1.0.1",
     "chai": "^3.4.1",
     "chai-http": "^1.0.0",
     "eslint": "^1.10.3",

--- a/src/middleware/serve.js
+++ b/src/middleware/serve.js
@@ -1,0 +1,28 @@
+import send from 'send';
+import parse from 'parseurl';
+
+/**
+ * Server static files with `send`.
+ * @param {Object} options Options based to `send`.
+ * @returns {Function} Middleware function.
+ */
+export default (options) => {
+  return function(app) {
+    const { error } = app;
+    return {
+      ...app,
+      request(req, res) {
+        const url = parse(req);
+        const path = req.path ?
+          url.pathname.substr(req.path.length) : url.pathname;
+        const stream = send(req, path, options);
+
+        stream
+          .on('error', error)
+          // .on('directory', redirect)
+          // .on('headers', headers)
+          .pipe(res);
+      },
+    };
+  };
+};

--- a/test/spec/middleware/serve.spec.js
+++ b/test/spec/middleware/serve.spec.js
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import bl from 'bl';
+
+import serve from '../../../src/middleware/serve';
+
+describe('serve', () => {
+  it('should serve some files', (done) => {
+    const spy = sinon.spy();
+    const getHeader = sinon.stub().returns('');
+    const setHeader = sinon.stub();
+    const stream = bl(() => {});
+    const app = serve({ root: __dirname })({
+      request: spy,
+      error: spy,
+    });
+    stream.getHeader = getHeader;
+    stream.setHeader = setHeader;
+    // fs.createReadStream('./base.js').pipe(stream);
+    app.request({ url: '/serve.spec.js', headers: {}, method: 'GET' }, stream);
+    setTimeout(() => {
+      expect(stream.setHeader).to.be.called;
+      done();
+    }, 2);
+  });
+
+  it('should work with path prefixes', (done) => {
+    const spy = sinon.spy();
+    const getHeader = sinon.stub().returns('');
+    const setHeader = sinon.stub();
+    const stream = bl(() => {});
+    const app = serve({ root: __dirname })({
+      request: spy,
+      error: spy,
+    });
+    stream.getHeader = getHeader;
+    stream.setHeader = setHeader;
+    // fs.createReadStream('./base.js').pipe(stream);
+    app.request({
+      url: '/foo/serve.spec.js',
+      path: '/foo',
+      headers: {},
+      method: 'GET',
+    }, stream);
+    setTimeout(() => {
+      expect(stream.setHeader).to.be.called;
+      done();
+    }, 2);
+  });
+});


### PR DESCRIPTION
A simple static file server is now easy as:

``` javascript
const createApp = compose(
  verbs.get('/foo', serve({ root: __dirname })),
  compose(status(404), send()),
);
```
